### PR TITLE
fix: create unique entites by prefixing the serial number

### DIFF
--- a/custom_components/pluggit/button.py
+++ b/custom_components/pluggit/button.py
@@ -79,7 +79,7 @@ class PluggitButton(ButtonEntity):
         self._pluggit = pluggit
         self.entity_description = description
         self._serial_number = str(serial_number)
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{serial_number}_{description.key}"
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_has_entity_name = True
         self._attr_available = False

--- a/custom_components/pluggit/config_flow.py
+++ b/custom_components/pluggit/config_flow.py
@@ -42,6 +42,7 @@ class PluggitConfigFlow(ConfigFlow, domain=DOMAIN):
             errors[CONFIG_HOST] = "No valid host or connection!"
             if ret is not None:
                 user_input[SERIAL_NUMBER] = ret
+                await self.async_set_unique_id(str(ret))
                 return self.async_create_entry(title="Pluggit", data=user_input)
 
         return self.async_show_form(

--- a/custom_components/pluggit/fan.py
+++ b/custom_components/pluggit/fan.py
@@ -68,7 +68,7 @@ class PluggitFan(FanEntity):
         self._pluggit = pluggit
         self._speedLevel = SpeedLevelFan.LEVEL_1
         self._currentMode = CURRENT_UNIT_MODE[0]
-        self._attr_unique_id = "fan"
+        self._attr_unique_id = f"{device['serial_number']}_fan"
         self._attr_available = False
         self._attr_has_entity_name = True
         self._attr_device_info = device

--- a/custom_components/pluggit/number.py
+++ b/custom_components/pluggit/number.py
@@ -140,7 +140,7 @@ class PluggitSensor(NumberEntity):
         self._pluggit = pluggit
         self.entity_description = description
         self._serial_number = str(serial_number)
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{serial_number}_{description.key}"
         self._attr_has_entity_name = True
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_available = False

--- a/custom_components/pluggit/select.py
+++ b/custom_components/pluggit/select.py
@@ -56,7 +56,7 @@ class PluggitSelect(SelectEntity):
         """Initialise Pluggit sensor."""
         self._pluggit = pluggit
         self._serial_number = str(serial_number)
-        self._attr_unique_id = "week_program"
+        self._attr_unique_id = f"{serial_number}_week_program"
         self._attr_translation_key = "select_week"
         self._attr_current_option = None
         self._attr_entity_category = EntityCategory.CONFIG

--- a/custom_components/pluggit/sensor.py
+++ b/custom_components/pluggit/sensor.py
@@ -263,7 +263,7 @@ class PluggitSensor(SensorEntity):
         self._pluggit = pluggit
         self.entity_description = description
         self._serial_number = str(serial_number)
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{serial_number}_{description.key}"
         self._attr_has_entity_name = True
         self._attr_available = False
         self._attr_device_info = DeviceInfo(

--- a/custom_components/pluggit/switch.py
+++ b/custom_components/pluggit/switch.py
@@ -103,7 +103,7 @@ class PluggitSwitch(SwitchEntity):
         self._pluggit = pluggit
         self.entity_description = description
         self._serial_number = str(serial_number)
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{serial_number}_{description.key}"
         self._attr_has_entity_name = True
         self._attr_available = False
         self._attr_is_on = False

--- a/custom_components/pluggit/time.py
+++ b/custom_components/pluggit/time.py
@@ -87,7 +87,7 @@ class PluggitTime(TimeEntity):
         self._pluggit = pluggit
         self.entity_description = description
         self._serial_number = str(serial_number)
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{serial_number}_{description.key}"
         self._attr_has_entity_name = True
         self._attr_available = False
         self._attr_native_value = None

--- a/custom_components/pluggit/valve.py
+++ b/custom_components/pluggit/valve.py
@@ -42,7 +42,7 @@ class PluggitValve(ValveEntity):
         """Initialise Pluggit valve."""
         self._pluggit = pluggit
         self._serial_number = str(serial_number)
-        self._attr_unique_id = "manual_bypass"
+        self._attr_unique_id = f"{serial_number}_manual_bypass"
         self._attr_translation_key = "manual_bypass"
         self._attr_has_entity_name = True
         self._attr_available = False


### PR DESCRIPTION
Fixes #11 by prefixing the entity unique_id field with the device serial number